### PR TITLE
feat: modify DATABASES OPTIONS settings

### DIFF
--- a/pnuNoti/settings/prod.py
+++ b/pnuNoti/settings/prod.py
@@ -24,7 +24,8 @@ DATABASES = {
         'HOST': MYSQL_HOST,
         'PORT': '3306',
         'OPTIONS': {
-            'charset': 'utf8mb4'
+            'charset': 'utf8mb4',
+            'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
         }
     },
 }


### PR DESCRIPTION
다음과 같은 추가사항이 있습니다.
- 배포환경에서 데이터베이스의 OPTIONS에 위해 'init_command': "SET sql_mode='STRICT_TRANS_TABLES'" 명령어를 추가했습니다.