### PR TITLE
Pull request fix/fixSendMail to develop

### DIFF
--- a/notice/management/commands/crontab_mail.py
+++ b/notice/management/commands/crontab_mail.py
@@ -1,6 +1,5 @@
 # django import
 from django.core.management.base import BaseCommand
-from django.utils import timezone
 from django.core.mail import send_mail
 from asgiref.sync import sync_to_async
 from django.conf import settings
@@ -30,6 +29,7 @@ def get_user_subscribes(notice: Notice):
 def reject_subscribe_email(failed_user: Set[str]):
     Subscribe.objects.filter(user__email__in=list(failed_user)).update(is_active=False)
 
+
 @sync_to_async
 def update_exec_time(notice: Notice, last_data_time: datetime):
     notice.updated_at = last_data_time
@@ -52,46 +52,68 @@ def get_message(user_subscribe, valid_item):
 작성자: {valid_item.get('author')}"""
 
 
+def send_failed_message_to_admin(failed_notices: List[Notice]):
+    send_data = f"발생 시각: {datetime.now()}\n"
+    for notice in failed_notices:
+        send_data += f"""'공지사항 ID': {notice.id}
+'공지사항 링크': {notice.rss_link}
+----------------------
+
+"""
+
+    send_mail(
+        subject='crontab_mail에서 에러가 발생했습니다.',
+        message=send_data,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        recipient_list=[admin[1] for admin in settings.ADMIN_EMAIL])
+
+
 async def send_rss_to_user(notice: Notice):
     """
     특정 학과의 공지사항을 받아와 마지막 갱신 시간보다 뒤에 등록된 글들을 구독한 회원들에게 메일전송
     """
-    response: Response = get(url=notice.rss_link)
-    res_xml: dict = xmltodict.parse(response.text)
-    res_items: List[dict] = res_xml['rss']['channel']['item']
-    res_filter = map(lambda x: {
-        'notice_title': x['title'],
-        'link': x['link'],
-        'pubDate': datetime.strptime(x['pubDate'], '%Y-%m-%d %H:%M:%S.%f'),
-        'author': x['author']}, res_items)
+    try:
+        response: Response = get(url=notice.rss_link, timeout=5)
+        res_xml: dict = xmltodict.parse(response.text)
+        res_items: List[dict] = res_xml['rss']['channel']['item']
+        res_filter = map(lambda x: {
+            'notice_title': x['title'],
+            'link': x['link'],
+            'pubDate': datetime.strptime(x['pubDate'], '%Y-%m-%d %H:%M:%S.%f'),
+            'author': x['author']}, res_items)
 
-    valid_items = list(filter(lambda x: notice.is_valid(x['pubDate']), res_filter))
-    last_data_time = valid_items[0]["pubDate"] if valid_items else -1
-    valid_items.reverse()
+        valid_items = list(filter(lambda x: notice.is_valid(x['pubDate']), res_filter))
+        last_data_time = valid_items[0]["pubDate"] if valid_items else -1
+        valid_items.reverse()
 
-    user_subscribes: List[Subscribe] = await get_user_subscribes(notice)
+        user_subscribes: List[Subscribe] = await get_user_subscribes(notice)
 
-    failed_mail_users = set()
-    for valid_item in valid_items:
-        valid_item['pubDate'] = valid_item['pubDate'].strftime("%Y-%m-%d %H:%M")
-        tasks = []
-        for s in user_subscribes:
-            send_mail_data = {
-                'subject': f"{s.title}: {valid_item.get('notice_title')}",
-                'message': get_message(s, valid_item),
-                'from_email': settings.DEFAULT_FROM_EMAIL,
-                'recipient_list': [s.user.email],
-                'fail_silently': False
-            }
-            tasks.append(send_mail_async(send_mail_data))
+        failed_mail_users = set()
+        for valid_item in valid_items:
+            valid_item['pubDate'] = valid_item['pubDate'].strftime("%Y-%m-%d %H:%M")
+            tasks = []
+            for s in user_subscribes:
+                send_mail_data = {
+                    'subject': f"{s.title}: {valid_item.get('notice_title')}",
+                    'message': get_message(s, valid_item),
+                    'from_email': settings.DEFAULT_FROM_EMAIL,
+                    'recipient_list': [s.user.email],
+                    'fail_silently': False
+                }
+                tasks.append(send_mail_async(send_mail_data))
 
-        failed_mail_users.update([task for task in await asyncio.gather(*tasks) if task != 1])
+            failed_mail_users.update([task for task in await asyncio.gather(*tasks) if task != 1])
 
-    if failed_mail_users:
-        await reject_subscribe_email(failed_mail_users)
+        if failed_mail_users:
+            await reject_subscribe_email(failed_mail_users)
 
-    if last_data_time != -1:
-        await update_exec_time(notice, last_data_time)
+        if last_data_time != -1:
+            await update_exec_time(notice, last_data_time)
+        return -1
+    except Exception as e:
+        print(e)
+        return notice.id
+
 
 class Command(BaseCommand):
     """
@@ -101,11 +123,24 @@ class Command(BaseCommand):
     help = '공지사항 이메일 전송입니다.'
 
     def handle(self, *args: Any, **options: Any) -> NoReturn:
-        rss_datas = Notice.objects.all()[:]
+        notices = Notice.objects.all()[:]
         start_time = time.time()
         loop = asyncio.get_event_loop()
-        tasks = list(map(lambda x: asyncio.ensure_future(send_rss_to_user(x)), rss_datas))
+        results = []
+        tasks = list(map(lambda x: asyncio.ensure_future(send_rss_to_user(x)), notices))
         if tasks:
-            loop.run_until_complete(asyncio.wait(tasks))
-        # Notice.objects.all().update(updated_at=timezone.now())
+            results = loop.run_until_complete(asyncio.wait(tasks))
+
+        failed_results = set(filter(
+            lambda x: x != -1,
+            results
+        ))
+
+        if failed_results and not settings.DEBUG:
+            failed_notices = list(filter(
+                lambda x: x.id in failed_results,
+                notices
+            ))
+            send_failed_message_to_admin(failed_notices)
+
         print("Total Execute Time = ", time.time() - start_time, "s")

--- a/notice/management/commands/crontab_mail.py
+++ b/notice/management/commands/crontab_mail.py
@@ -92,7 +92,7 @@ async def send_rss_to_user(notice: Notice):
     특정 학과의 공지사항을 받아와 마지막 갱신 시간보다 뒤에 등록된 글들을 구독한 회원들에게 메일전송
     """
     try:
-        response: Response = get(url=notice.rss_link, timeout=10)
+        response: Response = get(url=notice.rss_link, timeout=120)
         res_xml: dict = xmltodict.parse(response.text)
         res_items: List[dict] = res_xml['rss']['channel']['item']
         res_filter = map(lambda x: {

--- a/pnuNoti/backends.py
+++ b/pnuNoti/backends.py
@@ -1,0 +1,26 @@
+from django.core.mail.backends.smtp import EmailBackend
+from django.conf import settings
+import threading
+
+
+class AdminEmailBackend(EmailBackend):
+    def __init__(self, host=None, port=None, username=None, password=None,
+                 use_tls=None, fail_silently=False, use_ssl=None, timeout=None,
+                 ssl_keyfile=None, ssl_certfile=None,
+                 **kwargs):
+        super().__init__(fail_silently=fail_silently)
+        self.host = host or settings.EMAIL_HOST_ADMIN
+        self.port = port or settings.EMAIL_PORT_ADMIN
+        self.username = settings.EMAIL_HOST_USER_ADMIN if username is None else username
+        self.password = settings.EMAIL_HOST_PASSWORD_ADMIN if password is None else password
+        self.use_tls = settings.EMAIL_USE_TLS_ADMIN if use_tls is None else use_tls
+        self.use_ssl = settings.EMAIL_USE_SSL_ADMIN if use_ssl is None else use_ssl
+        self.timeout = settings.EMAIL_TIMEOUT if timeout is None else timeout
+        self.ssl_keyfile = settings.EMAIL_SSL_KEYFILE if ssl_keyfile is None else ssl_keyfile
+        self.ssl_certfile = settings.EMAIL_SSL_CERTFILE if ssl_certfile is None else ssl_certfile
+        if self.use_ssl and self.use_tls:
+            raise ValueError(
+                "EMAIL_USE_TLS/EMAIL_USE_SSL are mutually exclusive, so only set "
+                "one of those settings to True.")
+        self.connection = None
+        self._lock = threading.RLock()

--- a/pnuNoti/settings/base.py
+++ b/pnuNoti/settings/base.py
@@ -186,6 +186,7 @@ LOGGING = {
             'filters': ['require_debug_false'], # 배포 시에만 허용
             'class': 'django.utils.log.AdminEmailHandler',
             'include_html': True,
+            'email_backend': 'pnuNoti.backends.AdminEmailBackend',
         },
         # User Custom Start
         'file': {

--- a/pnuNoti/settings/local.py
+++ b/pnuNoti/settings/local.py
@@ -15,6 +15,7 @@ EMAIL_HOST_USER = get_secret("GMAIL_HOST")
 EMAIL_HOST_PASSWORD = get_secret("GMAIL_PASSWORD")
 DEFAULT_FROM_EMAIL = "부산대학교 공지사항 알리미"+f" <{EMAIL_HOST_USER}>"
 
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',

--- a/pnuNoti/settings/local.py
+++ b/pnuNoti/settings/local.py
@@ -3,7 +3,7 @@ from .base import *
 ALLOWED_HOSTS = ["*"]
 DEBUG = True
 
-ADMIN_EMAIL = get_secret("ADMIN_ID")
+ADMIN_EMAIL = get_secret("ADMIN_EMAIL")
 ADMIN_PW = get_secret("ADMIN_PW")
 
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'

--- a/pnuNoti/settings/local.py
+++ b/pnuNoti/settings/local.py
@@ -3,7 +3,7 @@ from .base import *
 ALLOWED_HOSTS = ["*"]
 DEBUG = True
 
-ADMIN_EMAIL = get_secret("ADMIN_EMAIL")
+ADMIN_EMAIL = get_secret("ADMIN_ID")
 ADMIN_PW = get_secret("ADMIN_PW")
 
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'

--- a/pnuNoti/settings/prod.py
+++ b/pnuNoti/settings/prod.py
@@ -4,12 +4,12 @@ import pymysql
 pymysql.install_as_MySQLdb()
 
 # 설정한 도메인만 가능하도록 변경
-ALLOWED_HOSTS = ['pnunoti.site', 'www.pnunoti.site', '*']
+ALLOWED_HOSTS = ['pnunoti.site', 'www.pnunoti.site']
 CSRF_TRUSTED_ORIGINS = ['https://pnunoti.site', 'https://www.pnunoti.site']
 DEBUG = False
 
 
-ADMIN_EMAIL = get_secret("ADMIN_ID")
+ADMIN_EMAIL = get_secret("ADMIN_EMAIL")
 ADMIN_PW = get_secret("ADMIN_PW")
 
 MYSQL_USER = get_secret("MYSQL_USER")
@@ -23,7 +23,7 @@ EMAIL_USE_TLS = False
 EMAIL_USE_SSL = True
 EMAIL_PORT = 465
 EMAIL_HOST_USER = get_secret("EMAIL_HOST")
-EMAIL_HOST_PASSWORD = get_secret("EMAIL_PASSWORD")[0]
+EMAIL_HOST_PASSWORD = get_secret("EMAIL_PASSWORD")
 DEFAULT_FROM_EMAIL = "부산대학교 공지사항 알리미"+f" <{EMAIL_HOST_USER}>"
 
 

--- a/pnuNoti/settings/prod.py
+++ b/pnuNoti/settings/prod.py
@@ -1,19 +1,21 @@
 from .base import *
-
 import pymysql
 
 pymysql.install_as_MySQLdb()
 
 # 설정한 도메인만 가능하도록 변경
-ALLOWED_HOSTS = ['pnunoti.site', 'www.pnunoti.site']
+ALLOWED_HOSTS = ['pnunoti.site', 'www.pnunoti.site', '*']
 CSRF_TRUSTED_ORIGINS = ['https://pnunoti.site', 'https://www.pnunoti.site']
 DEBUG = False
+
+
+ADMIN_EMAIL = get_secret("ADMIN_ID")
+ADMIN_PW = get_secret("ADMIN_PW")
 
 MYSQL_USER = get_secret("MYSQL_USER")
 MYSQL_PW = get_secret("MYSQL_PASSWORD")
 MYSQL_HOST = get_secret("MYSQL_HOST")
-ADMIN_EMAIL = get_secret("ADMIN_EMAIL")
-ADMIN_PW = get_secret("ADMIN_PW")
+
 
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = 'smtp.daum.net'
@@ -21,8 +23,18 @@ EMAIL_USE_TLS = False
 EMAIL_USE_SSL = True
 EMAIL_PORT = 465
 EMAIL_HOST_USER = get_secret("EMAIL_HOST")
-EMAIL_HOST_PASSWORD = get_secret("EMAIL_PASSWORD")
+EMAIL_HOST_PASSWORD = get_secret("EMAIL_PASSWORD")[0]
 DEFAULT_FROM_EMAIL = "부산대학교 공지사항 알리미"+f" <{EMAIL_HOST_USER}>"
+
+
+EMAIL_BACKEND_ADMIN = 'pnuNoti.backends.AdminEmailBackend'
+EMAIL_HOST_ADMIN = 'smtp.gmail.com'
+EMAIL_USE_TLS_ADMIN = True
+EMAIL_USE_SSL_ADMIN = False
+EMAIL_PORT_ADMIN = 587
+EMAIL_HOST_USER_ADMIN = get_secret("GMAIL_HOST")
+EMAIL_HOST_PASSWORD_ADMIN = get_secret("GMAIL_PASSWORD")
+DEFAULT_FROM_EMAIL_ADMIN = "부산대학교 공지사항 알리미"+f" <{EMAIL_HOST_USER_ADMIN}>"
 
 DATABASES = {
     'default': {

--- a/registration/management/commands/initadmin.py
+++ b/registration/management/commands/initadmin.py
@@ -10,7 +10,7 @@ User: CustomUser = get_user_model()
 class Command(BaseCommand):
 
     def handle(self, *args, **options):
-        user = User.objects.filter(email__iexact=settings.ADMIN_EMAIL)
+        user = User.objects.filter(email__iexact=settings.ADMIN_ID)
         if len(user) == 0:
             email = settings.ADMIN_EMAIL
             password = settings.ADMIN_PW

--- a/registration/management/commands/initadmin.py
+++ b/registration/management/commands/initadmin.py
@@ -10,7 +10,7 @@ User: CustomUser = get_user_model()
 class Command(BaseCommand):
 
     def handle(self, *args, **options):
-        user = User.objects.filter(email__iexact=settings.ADMIN_ID)
+        user = User.objects.filter(email__iexact=settings.ADMIN_EMAIL)
         if len(user) == 0:
             email = settings.ADMIN_EMAIL
             password = settings.ADMIN_PW

--- a/subscribe/views.py
+++ b/subscribe/views.py
@@ -50,6 +50,7 @@ class UpdateSubscribeView(WriterPermissionRequiredMixin, View):
         return get_object_or_404(Subscribe.objects.select_related("notice"), pk=pk)
 
     def get(self, request, pk):
+        1/0
         subscribe = self.get_object(pk)
 
         return render(request, self.template_name, {


### PR DESCRIPTION
다음과 같은 변경사항이 있습니다.
- github 레포지토리 README.md에 설명을 추가했습니다.
- 에러가 발생할 시 운영자에게 발송하는 메일 계정과 기존 사용자에게 보내는 메일 계정을 분리했습니다.
- 사용자에게 메일을 보낼 때 사용자가 구독한 공지사항에 대해 모두 SMTPRecipientsRefused 예외가 발생할 경우 사용자 메일 알림을 비활성화하는 로직을 추가했습니다.